### PR TITLE
Support exclusion of sub-directories

### DIFF
--- a/duplicity-take-backup.jinja
+++ b/duplicity-take-backup.jinja
@@ -17,20 +17,24 @@ set -o errexit
 # Backup selected directories
 /usr/local/bin/duplicity-exec \
   --full-if-older-than {{ full_if_older_than }} \
-  --exclude-device-files / \
+  --exclude-device-files {{ data_dir }} \
 {%- for dir in include_dirs %}
-  --include {{ dir }} \
+  --include '{{ dir }}' \
 {%- endfor %}
-  --exclude '**'
+{%- for dir in exclude_dirs %}
+  --exclude '{{ dir }}'
+{%- endfor %}
 
 {% if verify %}
 # Verify backup (takes quite a while)
 /usr/local/bin/duplicity-exec verify \
-  --exclude-device-files / \
+  --exclude-device-files {{ data_dir }} \
 {%- for dir in include_dirs %}
-  --include {{ dir }} \
+  --include '{{ dir }}' \
 {%- endfor %}
-  --exclude '**'
+{%- for dir in exclude_dirs %}
+  --exclude '{{ dir }}'
+{%- endfor %}
 {%- endif %}
 
 {% for cmd in exec_post %}

--- a/init.sls
+++ b/init.sls
@@ -67,7 +67,9 @@ ssh-keyscan {{ pillar['duplicity']['ssh']['known_hosts'] }} >> /etc/ssh/ssh_know
     - defaults:
       remove_all_but_n_full: {{ pillar['duplicity']['remove_all_but_n_full']|default(5) }}
       full_if_older_than: {{ pillar['duplicity']['full_if_older_than']|default('30D') }}
-      include_dirs: {{ pillar['duplicity']['include_dirs']|default(['/etc', '/root']) }}
+      data_dir: {{ salt['pillar.get']('duplicity:data_dir', '/') }}
+      include_dirs: {{ salt['pillar.get']('duplicity:include_dirs', []) }}
+      exclude_dirs: {{ salt['pillar.get']('duplicity:exclude_dirs', ['**']) }}
       exec_pre: {{ pillar['duplicity']['exec_pre']|default([]) }}
       exec_post: {{ pillar['duplicity']['exec_post']|default([]) }}
       verify: {{ pillar['duplicity']['verify']|default(true) }}


### PR DESCRIPTION
The primary motivation here is to support exclusion of sub-directories which might be desirable in certain cases. This shall not affect any existing setups as the default values remain the same.

