### PR TITLE
Use a fixed source path for simplicity

### DIFF
--- a/duplicity-take-backup.jinja
+++ b/duplicity-take-backup.jinja
@@ -17,24 +17,26 @@ set -o errexit
 # Backup selected directories
 /usr/local/bin/duplicity-exec \
   --full-if-older-than {{ full_if_older_than }} \
-  --exclude-device-files {{ data_dir }} \
-{%- for dir in include_dirs %}
-  --include '{{ dir }}' \
-{%- endfor %}
+  --exclude-device-files / \
 {%- for dir in exclude_dirs %}
   --exclude '{{ dir }}'
 {%- endfor %}
+{%- for dir in include_dirs %}
+  --include '{{ dir }}' \
+{%- endfor %}
+ --exclude '**'
 
 {% if verify %}
 # Verify backup (takes quite a while)
 /usr/local/bin/duplicity-exec verify \
-  --exclude-device-files {{ data_dir }} \
-{%- for dir in include_dirs %}
-  --include '{{ dir }}' \
-{%- endfor %}
+  --exclude-device-files / \
 {%- for dir in exclude_dirs %}
   --exclude '{{ dir }}'
 {%- endfor %}
+{%- for dir in include_dirs %}
+  --include '{{ dir }}' \
+{%- endfor %}
+ --exclude '**'
 {%- endif %}
 
 {% for cmd in exec_post %}

--- a/init.sls
+++ b/init.sls
@@ -67,9 +67,8 @@ ssh-keyscan {{ pillar['duplicity']['ssh']['known_hosts'] }} >> /etc/ssh/ssh_know
     - defaults:
       remove_all_but_n_full: {{ pillar['duplicity']['remove_all_but_n_full']|default(5) }}
       full_if_older_than: {{ pillar['duplicity']['full_if_older_than']|default('30D') }}
-      data_dir: {{ salt['pillar.get']('duplicity:data_dir', '/') }}
       include_dirs: {{ salt['pillar.get']('duplicity:include_dirs', []) }}
-      exclude_dirs: {{ salt['pillar.get']('duplicity:exclude_dirs', ['**']) }}
+      exclude_dirs: {{ salt['pillar.get']('duplicity:exclude_dirs', []) }}
       exec_pre: {{ pillar['duplicity']['exec_pre']|default([]) }}
       exec_post: {{ pillar['duplicity']['exec_post']|default([]) }}
       verify: {{ pillar['duplicity']['verify']|default(true) }}


### PR DESCRIPTION
This would simplify the logic to look something like:

```
duplicity --full-if-older-than 7D --exclude-device-files /   --exclude '/tmp/parent/child2' --include '/tmp/parent'  --exclude '**'     file:///tmp/backup/ --no-encryption --dry-run
```

1. Read everything from root.
2. Exclude specified subdir(s)
3. Include the parent dir
4. Exclude everything else

The order is of utmost importance here .