### PR TITLE
Allow usage of multi backend

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -14,24 +14,28 @@ duplicity:
       - duplicity
     {% if 'ftp://' in pillar['duplicity']['backend'] or 'ftp://' in pillar['duplicity']['multi_config'] %}
       - lftp
-    {% elif 'boto3+s3://' in pillar['duplicity']['backend'] or 'boto3+s3://' in pillar['duplicity']['multi_config'] %}
+    {% endif %}
+    {% if 'boto3+s3://' in pillar['duplicity']['backend'] or 'boto3+s3://' in pillar['duplicity']['multi_config'] %}
       - python3-boto3
-    {% elif 's3' in pillar['duplicity']['backend'] or 's3' in pillar['duplicity']['multi_config'] %}
+    {% endif %}
+    {% if 's3' in pillar['duplicity']['backend'] or 's3' in pillar['duplicity']['multi_config'] %}
       - python3-boto
-    {% elif 'scp://' in pillar['duplicity']['backend'] or 'scp://' in pillar['duplicity']['multi_config'] %}
+    {% endif %}
+    {% if 'scp://' in pillar['duplicity']['backend'] or 'scp://' in pillar['duplicity']['multi_config'] %}
       - python3-paramiko
     {% endif %}
 
 # Insert duplicity multi configuration
 {% if 'multi://' in pillar['duplicity']['backend'] %}
 # Deploy scripts
-/etc/xdg/duplicity/multi.json:
+/etc/duplicity/multi.json:
   file.managed:
     - user: root
     - group: root
     - mode: 700
     - makedirs: true
-    - content: {{ pillar['duplicity']['multi_config'] | tojson }}
+    - contents_pillar: duplicity:multi_config
+    - serializer: json
 {% endif %}
 
 # Deploy SSH keys

--- a/init.sls
+++ b/init.sls
@@ -10,15 +10,29 @@ duplicity_ppa_repo:
 
 duplicity:
   pkg.installed:
-    {% if 'ftp://' in pillar['duplicity']['backend'] %}
-    - pkgs: [duplicity, lftp]
-    {% elif 'boto3+s3' in pillar['duplicity']['backend'] %}
-    - pkgs: [duplicity, python3-boto3]
-    {% elif 's3' in pillar['duplicity']['backend'] %}
-    - pkgs: [duplicity, python3-boto]
-    {% elif 'scp://' in pillar['duplicity']['backend'] %}
-    - pkgs: [duplicity, python3-paramiko]
+    - pkgs:
+      - duplicity
+    {% if 'ftp://' in pillar['duplicity']['backend'] or 'ftp://' in pillar['duplicity']['multi_config'] %}
+      - lftp
+    {% elif 'boto3+s3://' in pillar['duplicity']['backend'] or 'boto3+s3://' in pillar['duplicity']['multi_config'] %}
+      - python3-boto3
+    {% elif 's3' in pillar['duplicity']['backend'] or 's3' in pillar['duplicity']['multi_config'] %}
+      - python3-boto
+    {% elif 'scp://' in pillar['duplicity']['backend'] or 'scp://' in pillar['duplicity']['multi_config'] %}
+      - python3-paramiko
     {% endif %}
+
+# Insert duplicity multi configuration
+{% if 'multi://' in pillar['duplicity']['backend'] %}
+# Deploy scripts
+/etc/xdg/duplicity/multi.json:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 700
+    - makedirs: true
+    - content: {{ pillar['duplicity']['multi_config'] | tojson }}
+{% endif %}
 
 # Deploy SSH keys
 {% if pillar['duplicity']['ssh'] is defined %}

--- a/pillar.example
+++ b/pillar.example
@@ -2,9 +2,39 @@
 
 duplicity:
   passphrase: your-super-secret-passphrase
-  backend: ftp://user:pass@your-server.com/mybackup
-  args: --s3-endpoint-url https://example.endpoint.com --s3-european-buckets
+  # FTP example
+  # backend: ftp://user:pass@your-server.com/mybackup
 
+  # Multi example
+  # First bucket will use other credentials the the default AWS credentials provided below
+  backend: multi:///etc/duplicity/multi.json?mode=mirror&onfail=abort
+  multi_config: |
+    [
+      {
+        "description": "Main AWS S3 bucket",
+        "url": "boto3+s3://main-backup/subdir",
+        "env": [
+          {
+          "name" : "AWS_ACCESS_KEY_ID",
+          "value" : "xyz"
+          },
+          {
+          "name" : "AWS_SECRET_ACCESS_KEY",
+          "value" : "bar"
+          }
+        ]
+      },
+      {
+        "description": "Seconday AWS S3 bucket",
+        "url": "s3://secondary-backup/subdir"
+      },
+      {
+        "description": "Any FTP backend",
+        "url": "ftp://user:pass@your-server.com/mybackup"
+      }
+    ]
+
+  # args: --s3-endpoint-url https://example.endpoint.com --s3-european-buckets
   # AWS credentials (only required when S3 is used)
   aws_access_key_id: your-access-key-id
   aws_secret_access_key: your-secret-access-key


### PR DESCRIPTION
I want to be able to use the duplicity multi backend. With this we could use a `multi.json` file like this:

```json
    [
      {
        "description": "Main AWS S3 bucket",
        "url": "boto3+s3://backup/my-tool",
      },
      {
        "description": "Seconday AWS S3 bucket",
        "url": "boto3+s3://backup-in-other-region/my-tool"
      }
    ]
```

with the backend being `multi:///etc/xdg/duplicity/multi.json?mode=mirror&onfail=abort` this would create a RAID1 mirror on all backends defined in `multi.conf`

See here for more details: https://manpages.ubuntu.com/manpages/impish/en/man1/duplicity.1.html#a%20note%20on%20multi%20backend