### PR TITLE
Specify "incremental" command to not rely on implied commands

### DIFF
--- a/duplicity-take-backup.jinja
+++ b/duplicity-take-backup.jinja
@@ -15,7 +15,7 @@ set -o errexit
 {%- endfor %}
 
 # Backup selected directories
-/usr/local/bin/duplicity-exec \
+/usr/local/bin/duplicity-exec incremental \
   --full-if-older-than {{ full_if_older_than }} \
   --exclude-device-files / \
 {%- for dir in exclude_dirs %}


### PR DESCRIPTION
Duplicity 2.0 has removed implied commands: https://gitlab.com/duplicity/duplicity/-/issues/152

Also being discussed in: https://gitlab.com/duplicity/duplicity/-/issues/728